### PR TITLE
ログイン後にuser/registerを叩いてもnotes/indexに移動するようにした

### DIFF
--- a/fuel/app/classes/controller/users.php
+++ b/fuel/app/classes/controller/users.php
@@ -102,6 +102,10 @@ class Controller_Users extends Controller_Base
     {
         $this->template->title = '新規登録';
         $this->template->content = View::forge('users/register');
+
+        if (Auth::check()) {
+            Response::redirect('notes/index');
+        }
     }
 
     public function post_create()

--- a/fuel/app/logs/2025/08/26.php
+++ b/fuel/app/logs/2025/08/26.php
@@ -332,3 +332,9 @@ WARNING - 2025-08-26 20:10:04 --> Fuel\Core\Fuel::init - The configured locale j
 WARNING - 2025-08-26 20:10:12 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
 WARNING - 2025-08-26 20:10:12 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
 WARNING - 2025-08-26 20:10:12 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
+WARNING - 2025-08-26 20:16:51 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
+WARNING - 2025-08-26 20:16:51 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
+WARNING - 2025-08-26 20:16:52 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
+WARNING - 2025-08-26 20:16:53 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
+WARNING - 2025-08-26 20:16:53 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.
+WARNING - 2025-08-26 20:16:53 --> Fuel\Core\Fuel::init - The configured locale ja_JP.utf8 is not installed on your system.


### PR DESCRIPTION
新規登録機能をAuthパッケージのcheckメソッドを使ってログイン状態では叩けなくした

**Todo List**
- Authクラスを使ったユーザー機能の実装
- 新規登録(register)機能
- ログイン(login)機能
- ログアウト(logout)機能
- Note機能の実装
- ノートの作成機能
- ノートの削除機能
- 内容の編集機能(データバインドを使って動的に編集内容が保存される)
- セキュリティ
- CSRF対策
- Securityクラスのcheckメソッドを使ったtoken検証を実装する
