### PR TITLE
ノート詳細ページからのdeleteメソッドを実装した

### DIFF
--- a/fuel/app/classes/controller/notes.php
+++ b/fuel/app/classes/controller/notes.php
@@ -173,9 +173,8 @@ class Controller_Notes extends Controller_Base
             )), 404)->set_header('Content-Type', 'application/json');
         }
     }
-    /**
-     * API: ノート更新（自動保存用）
-     */
+
+    // ノート更新
     public function put_api_update($id = null)
     {
         $this->is_api_request = true;

--- a/fuel/app/logs/2025/09/02.php
+++ b/fuel/app/logs/2025/09/02.php
@@ -61,3 +61,4 @@ WARNING - 2025-09-02 12:38:03 --> Fuel\Core\Fuel::init - The configured locale j
 WARNING - 2025-09-02 12:38:25 --> Fuel\Core\Fuel::init - The configured locale null is not installed on your system.
 WARNING - 2025-09-02 12:38:25 --> Fuel\Core\Fuel::init - The configured locale null is not installed on your system.
 WARNING - 2025-09-02 12:38:25 --> Fuel\Core\Fuel::init - The configured locale null is not installed on your system.
+ERROR - 2025-09-02 12:55:35 --> Note deletion error: ノートが見つかりません

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -376,37 +376,32 @@ function NoteDetailViewModel(noteId) {
     };
 
     // ノートの削除
-    self.deleteNote = function() {
-        // OK/Cancelのダイアログでtrue/falseを取得
-        if (!confirm("このノートを削除しますか？")) {
-            return;
-        }
+    self.deleteNote = function()
+    {
+        if (!confirm("このノートを削除しますか？")) return;
 
-        // ノート詳細ページを見ているnoteIdを受け取りURLに含めてDELETEリクエストを送信
-        fetch("/notes/api/delete/" + self.noteId, {
-            method: "DELETE",
-            headers: {
-                "X-Requested-With": "XMLHttpRequest"
-            }
+        self.isLoading(true);
+
+        fetch("/notes/api/delete_note", {
+            method: "POST", // FuelPHP が DELETE 非対応なら POST でOK
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ id: noteId })
         })
-        .then(res => {
-            // HTTPレスポンスをチェックしてからJSONを返す
-            if (!res.ok) {
-                throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-            }
-            return res.json();
-        })
+        .then(res => res.json())
         .then(data => {
             if (data.success) {
-                alert("ノートを削除しました");
+                alert("削除しました");
+                // 配列から remove ではなく一覧ページへ戻す
                 window.location.href = "/notes/index";
             } else {
-                self.errorMessage(data.message || "削除に失敗しました");
+                self.errorMessage(data.message || "ノートの削除に失敗しました");
             }
         })
-        .catch(err => {
-            console.error("Delete note error:", err);
-            self.errorMessage("削除中にエラーが発生しました");
+        .catch(() => {
+            self.errorMessage("通信エラーが発生しました");
+        })
+        .finally(() => {
+            self.isLoading(false);
         });
     };
 


### PR DESCRIPTION
ノート詳細ページからのdeleteメソッドを実装した
詳細ページからの削除専用のメソッドを作成するか、indexページからの関数を使うか悩んだが、同じような内容を記載するのではなく、用意した関数を使う事ができるようにpostメソッドでdeleteを実装した

**Todo List**
- Authクラスを使ったユーザー機能の実装
- 新規登録(register)機能
- ログイン(login)機能
- ログアウト(logout)機能
- Note機能の実装
- ノートの作成機能
- ノートの削除機能
- 内容の編集機能(データバインドを使って動的に編集内容が保存される)
- セキュリティ
- CSRF対策
- Securityクラスのcheckメソッドを使ったtoken検証を実装する
