### PR TITLE
重複したusernameで新規登録ができない事とフラッシュメッセージの表示を行った

### DIFF
--- a/fuel/app/classes/controller/users.php
+++ b/fuel/app/classes/controller/users.php
@@ -118,20 +118,29 @@ class Controller_Users extends Controller_Base
         $username = Input::post('username');
         $password = Input::post('password');
 
-        if (Model_User::create_user($username, $password)) {
-            if (Auth::login($username, $password)) {
-                return Response::redirect('/notes/index');
+        try {
+            
+            $user_id = Model_User::create_user($username, $password); 
+            
+            if ($user_id) {
+                if (Auth::login($username, $password)) {
+                    return Response::redirect('/notes/index');
+                } else {
+                    return Response::forge(json_encode([
+                        'success' => false,
+                        'message' => '自動ログインに失敗しました。'
+                    ]))->set_header('Content-Type', 'application/json');
+                }
             } else {
                 return Response::forge(json_encode([
                     'success' => false,
-                    'message' => '自動ログインに失敗しました。'
+                    'message' => 'ユーザー登録に失敗しました。'
                 ]))->set_header('Content-Type', 'application/json');
             }
-        }else {
-            return Response::forge(json_encode([
-                'success' => false,
-                'message' => '新規登録に失敗しました。'
-            ]))->set_header('Content-Type', 'application/json');
+        } catch (\Exception $e) {
+            \Session::set_flash('error', 'ユーザー名はすでに使われています');
+
+            return \Response::redirect('/users/register');
         }
     }
 

--- a/fuel/app/logs/2025/09/02.php
+++ b/fuel/app/logs/2025/09/02.php
@@ -62,3 +62,4 @@ WARNING - 2025-09-02 12:38:25 --> Fuel\Core\Fuel::init - The configured locale n
 WARNING - 2025-09-02 12:38:25 --> Fuel\Core\Fuel::init - The configured locale null is not installed on your system.
 WARNING - 2025-09-02 12:38:25 --> Fuel\Core\Fuel::init - The configured locale null is not installed on your system.
 ERROR - 2025-09-02 12:55:35 --> Note deletion error: ノートが見つかりません
+ERROR - 2025-09-02 14:21:40 --> 1062 - Duplicate entry 'test1' for key 'users.unique_username' [ INSERT INTO `users` (`username`, `password`) VALUES ('test1', '3tixmHFPsel/ypuva8ySp1sFOB+vZVwP5gQw4Sl6YM0=') ] in /var/www/html/my_fuel_project/fuel/core/classes/database/mysqli/connection.php on line 292

--- a/fuel/app/views/users/register.php
+++ b/fuel/app/views/users/register.php
@@ -2,6 +2,12 @@
         <div class="form-container">
             <h1>新規登録</h1>
 
+            <?php if (Session::get_flash('error')): ?>
+                <div class="alert alert-danger">
+                    <?= Session::get_flash('error'); ?>
+                </div>
+            <?php endif; ?>
+
             <form action="<?php echo Uri::create('users/create'); ?>" method="post">
                 <div class="form-group">
                     <label for="username">ユーザー名:</label>


### PR DESCRIPTION
user登録の際にテーブルのusernameカラムにUNIQUE規制をかけていなかったため重複したデータが存在してしまっていた。
テーブルにUNIQUE設定を入れる、重複したusernameでログインしようとした際にはFlashメッセージをセットするようにした

**Todo List**
- Authクラスを使ったユーザー機能の実装
- 新規登録(register)機能
- ログイン(login)機能
- ログアウト(logout)機能
- Note機能の実装
- ノートの作成機能
- ノートの削除機能
- 内容の編集機能(データバインドを使って動的に編集内容が保存される)
- セキュリティ
- CSRF対策
- Securityクラスのcheckメソッドを使ったtoken検証を実装する
